### PR TITLE
feat(project-config): add local project's configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,22 @@ require("header").setup({
 })
 ```
 
+The default configuration can be overwritten by a local project `header.config` file with the following format:
+
+```lua
+return {
+    file_name = true,
+    author = "Your Name",
+    project = "Your Project",
+    date_created = true,
+    date_created_fmt = "%Y-%m-%d %H:%M:%S",
+    date_modified = true,
+    date_modified_fmt = "%Y-%m-%d %H:%M:%S",
+    line_separator = "------",
+    copyright_text = "Copyright (c) 2023 Your Name",
+}
+```
+
 Example:
 
 ```lua

--- a/lua/header.lua
+++ b/lua/header.lua
@@ -269,8 +269,40 @@ local function create_autocmds()
     end, { complete = "file", nargs = "?", bang = true })
 end
 
+local function read_config_file()
+    local config_file = io.open("header.config", "r")
+    if not config_file then
+        return nil
+    end
+
+    local config_content = config_file:read("*a")
+    config_file:close()
+
+    if not config_content then
+        return nil
+    end
+
+    -- Parse configuration content
+    local program = loadstring(config_content)
+    if not program then
+        return nil
+    end
+
+    return program()
+end
+
 header.setup = function(params)
+    -- Read the project configuration file
+    local file_config = read_config_file()
+
+    -- Override header config with params passed to setup
     header.config = vim.tbl_extend("force", header.config, params or {})
+
+    -- Override the default configuration with the project's configuration
+    if file_config then
+        header.config = vim.tbl_extend("force", header.config, file_config)
+    end
+
     create_autocmds()
 end
 


### PR DESCRIPTION
Hello! 👋

I'd like to suggest a new feature that enables developers to set up a local project configuration file named header.config. This file would override the default settings, providing more flexibility and customization options for individual projects.

This has been very useful for me, and I believe it could be beneficial for others as well 😄 

Best regards,