### PR TITLE
feat(ft): migrate existing config format to JSON and rename configuration file to `.header.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,19 +58,19 @@ require("header").setup({
 })
 ```
 
-The default configuration can be overwritten by a local project `header.config` file with the following format:
+The default configuration can be overwritten by a local project `.header.nvim` file with the following format:
 
-```lua
-return {
-    file_name = true,
-    author = "Your Name",
-    project = "Your Project",
-    date_created = true,
-    date_created_fmt = "%Y-%m-%d %H:%M:%S",
-    date_modified = true,
-    date_modified_fmt = "%Y-%m-%d %H:%M:%S",
-    line_separator = "------",
-    copyright_text = "Copyright (c) 2023 Your Name",
+```json
+{
+  "file_name": true,
+  "author": "Your Name",
+  "project": "Your Project",
+  "date_created": true,
+  "date_created_fmt": "%Y-%m-%d %H:%M:%S",
+  "date_modified": true,
+  "date_modified_fmt": "%Y-%m-%d %H:%M:%S",
+  "line_separator": "------",
+  "copyright_text": "Copyright (c) 2023 Your Name"
 }
 ```
 

--- a/lua/header.lua
+++ b/lua/header.lua
@@ -270,25 +270,19 @@ local function create_autocmds()
 end
 
 local function read_config_file()
-    local config_file = io.open("header.config", "r")
-    if not config_file then
+    local header_file = io.open(".header.nvim", "r")
+    if not header_file then
         return nil
     end
 
-    local config_content = config_file:read("*a")
-    config_file:close()
+    local header_file_content = header_file:read("*a")
+    header_file:close()
 
-    if not config_content then
+    if not header_file_content or header_file_content == "" then
         return nil
     end
 
-    -- Parse configuration content
-    local program = loadstring(config_content)
-    if not program then
-        return nil
-    end
-
-    return program()
+    return vim.fn.json_decode(header_file_content)
 end
 
 header.setup = function(params)


### PR DESCRIPTION
Switched to using Lua’s built-in JSON parser for config loading and renamed the config file to `.header.nvim` to follow dotfile conventions.

Keeping it hidden makes it less intrusive in the project root and aligns better with how user-specific or tool-specific configs are typically handled.