### PR TITLE
[Feature] Add ability to configure comment style

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The script comes with the following defaults:
     date_modified = true,
     date_modified_fmt = "%Y-%m-%d %H:%M:%S",
     line_separator = "------",
+    use_block_header = true,
     copyright_text = nil,
     license_from_file = false,
 }
@@ -72,6 +73,7 @@ require("header").setup({
     date_modified = true,
     date_modified_fmt = "%Y-%m-%d %H:%M:%S",
     line_separator = "------",
+    use_block_header = false,
     copyright_text = "Copyright 2023",
     license_from_file = false,
 })
@@ -124,6 +126,7 @@ The default configuration can be overwritten by a local project `.header.nvim` f
   "date_modified": true,
   "date_modified_fmt": "%Y-%m-%d %H:%M:%S",
   "line_separator": "------",
+  "use_block_header": true,
   "copyright_text": "Copyright (c) 2023 Your Name"
 }
 ```

--- a/lua/header.lua
+++ b/lua/header.lua
@@ -1,3 +1,11 @@
+--[[
+-- File name: header.lua
+-- Author: Samuel Boyden
+-- Date created: 2025-08-10
+-- Date modified: 2025-08-10
+-- All rights reserved.
+--]]
+
 local filetype_table = require("filetypes")
 
 local header = {}
@@ -413,7 +421,7 @@ local function update_date_modified()
         vim.notify("File type not supported for updating header", vim.log.levels.WARN)
         return
     end
-    local comments = filetype_table[file_extension]()
+    local comments = filetype_table[file_extension](header.config.use_block_header)
     local lines = get_header_lines(buffer, comments)
 
     if #lines > 0 and header.config.date_modified then

--- a/lua/header.lua
+++ b/lua/header.lua
@@ -87,31 +87,6 @@ local function escape_special_characters(pattern)
     return pattern
 end
 
--- local function find_block_comment_end(lines, comments)
---     local start_pat = escape_special_characters(comments.block.start or "")
---     local end_pat = escape_special_characters(comments.block["end"] or "")
---
---     if start_pat == "" or end_pat == "" then
---         return 0 -- Cannot proceed without both start and end
---     end
---
---     local found_start = false
---
---     for i, line in ipairs(lines) do
---         if not found_start then
---             if line:find(start_pat) then
---                 found_start = true
---             end
---         else
---             if line:find(end_pat) then
---                 return i -- End of block header (inclusive)
---             end
---         end
---     end
---
---     return 0 -- No complete block comment found
--- end
-
 local function find_header_comment_end(lines, comments)
     if not comments and not comments.line then
         return 0
@@ -126,12 +101,11 @@ local function find_header_comment_end(lines, comments)
     local last_comment_line = 0
 
     for i, line in ipairs(lines) do
-        -- stylua: ignore start
         if
-            (line_comment_pat   ~= "" and line:match("^%s*" .. line_comment_pat))
+            (line_comment_pat ~= "" and line:match("^%s*" .. line_comment_pat))
             or (block_start_pat ~= "" and line:match("^%s*" .. block_start_pat))
-            or (block_line_pat  ~= "" and line:match("^%s*" .. block_line_pat))
-            or (block_end_pat   ~= "" and line:match("^%s*" .. block_end_pat))
+            or (block_line_pat ~= "" and line:match("^%s*" .. block_line_pat))
+            or (block_end_pat ~= "" and line:match("^%s*" .. block_end_pat))
         then
             last_comment_line = i
         elseif line:match("^%s*$") then -- shortcircuit on the first white-space only/empty line
@@ -140,7 +114,6 @@ local function find_header_comment_end(lines, comments)
         else
             break
         end
-        -- stylua: ignore end
     end
 
     return last_comment_line

--- a/lua/header.lua
+++ b/lua/header.lua
@@ -128,8 +128,11 @@ local function find_line_comment_header_end(lines, comments)
     local last_comment_line = 0
 
     for i, line in ipairs(lines) do
-        if line:match(comment_pat) or line:match("^%s*$") then
+        if line:match(comment_pat) then
             last_comment_line = i
+        elseif line:match("^%s*$") then
+            last_comment_line = i
+            break
         else
             break
         end

--- a/lua/header.lua
+++ b/lua/header.lua
@@ -14,6 +14,7 @@ header.config = {
     date_modified = true,
     date_modified_fmt = "%Y-%m-%d %H:%M:%S",
     line_separator = "------",
+    use_block_header = true,
     copyright_text = nil,
     license_from_file = false,
 }
@@ -372,7 +373,7 @@ local function add_headers()
     if fn then
         prepare_headers(function(headers)
             if headers then
-                local comments = fn()
+                local comments = fn(header.config.use_block_header)
                 remove_old_headers(comments)
                 local commented_headers = comment_headers(headers, comments)
                 local buffer = vim.api.nvim_get_current_buf()
@@ -395,7 +396,7 @@ local function add_license_header(opts)
         license = replace_token(license, "organization", header.config.author)
         license = replace_token(license, "year", os.date("%Y"))
         local license_table = string_to_table(license)
-        local comments = fn()
+        local comments = fn(header.config.use_block_header)
         remove_old_headers(comments)
         local commented_headers = comment_headers(license_table, comments)
         vim.api.nvim_buf_set_lines(buffer, 0, 0, false, commented_headers)
@@ -528,6 +529,7 @@ header.reset = function()
         date_modified = true,
         date_modified_fmt = "%Y-%m-%d %H:%M:%S",
         line_separator = "------",
+        use_block_header = true,
         copyright_text = nil,
         license_from_file = false,
     }

--- a/lua/header.lua
+++ b/lua/header.lua
@@ -1,11 +1,3 @@
---[[
--- File name: header.lua
--- Author: Samuel Boyden
--- Date created: 2025-08-10
--- Date modified: 2025-08-10
--- All rights reserved.
---]]
-
 local filetype_table = require("filetypes")
 
 local header = {}

--- a/lua/languages.lua
+++ b/lua/languages.lua
@@ -1,109 +1,13 @@
 local languages = {}
-languages.cpp = function()
+languages.cpp = function(use_block_header)
     local comments = {
-        comment_start = "/*",
-        comment = "*",
-        comment_end = "*/",
+        comment_start = use_block_header and "/*" or nil,
+        comment = use_block_header and "*" or "//",
+        comment_end = use_block_header and "*/" or nil,
     }
     return comments
 end
-languages.python = function()
-    local comments = {
-        comment_start = nil,
-        comment = "#",
-        comment_end = nil,
-    }
-    return comments
-end
-languages.lua = function()
-    local comments = {
-        comment_start = "--[[",
-        comment = "--",
-        comment_end = "--]]",
-    }
-    return comments
-end
-languages.java = function()
-    local comments = {
-        comment_start = "/*",
-        comment = "*",
-        comment_end = "*/",
-    }
-    return comments
-end
-languages.javascript = function()
-    local comments = {
-        comment_start = "/*",
-        comment = "*",
-        comment_end = "*/",
-    }
-    return comments
-end
-languages.csharp = function()
-    local comments = {
-        comment_start = "/*",
-        comment = "*",
-        comment_end = "*/",
-    }
-    return comments
-end
-languages.swift = function()
-    local comments = {
-        comment_start = "/*",
-        comment = "*",
-        comment_end = "*/",
-    }
-    return comments
-end
-languages.ruby = function()
-    local comments = {
-        comment_start = "=begin",
-        comment = "#",
-        comment_end = "=end",
-    }
-    return comments
-end
-languages.kotlin = function()
-    local comments = {
-        comment_start = "/*",
-        comment = "*",
-        comment_end = "*/",
-    }
-    return comments
-end
-languages.scala = function()
-    local comments = {
-        comment_start = "/*",
-        comment = "*",
-        comment_end = "*/",
-    }
-    return comments
-end
-languages.go = function()
-    local comments = {
-        comment_start = "/*",
-        comment = "*",
-        comment_end = "*/",
-    }
-    return comments
-end
-languages.rust = function()
-    local comments = {
-        comment_start = "/*",
-        comment = "*",
-        comment_end = "*/",
-    }
-    return comments
-end
-languages.php = function()
-    local comments = {
-        comment_start = "/*",
-        comment = "*",
-        comment_end = "*/",
-    }
-    return comments
-end
-languages.shell = function()
+languages.python = function(_)
     local comments = {
         comment_start = nil,
         comment = "#",
@@ -111,55 +15,219 @@ languages.shell = function()
     }
     return comments
 end
-languages.haskell = function()
+languages.lua = function(use_block_header)
+    if use_block_header ~= nil then
+        use_block_header = true
+    end
+
     local comments = {
-        comment_start = "{-",
+        comment_start = use_block_header and "--[[" or nil,
         comment = "--",
-        comment_end = "-}",
+        comment_end = use_block_header and "--]]" or nil,
     }
     return comments
 end
-languages.perl = function()
+languages.java = function(use_block_header)
+    if use_block_header ~= nil then
+        use_block_header = true
+    end
+
     local comments = {
-        comment_start = "=pod",
+        comment_start = use_block_header and "/*" or nil,
+        comment = use_block_header and "*" or "//",
+        comment_end = use_block_header and "*/" or nil,
+    }
+    return comments
+end
+languages.javascript = function(use_block_header)
+    if use_block_header ~= nil then
+        use_block_header = true
+    end
+
+    local comments = {
+        comment_start = use_block_header and "/*" or nil,
+        comment = use_block_header and "*" or "//",
+        comment_end = use_block_header and "*/" or nil,
+    }
+    return comments
+end
+languages.csharp = function(use_block_header)
+    if use_block_header ~= nil then
+        use_block_header = true
+    end
+
+    local comments = {
+        comment_start = use_block_header and "/*" or nil,
+        comment = use_block_header and "*" or "//",
+        comment_end = use_block_header and "*/" or nil,
+    }
+    return comments
+end
+languages.swift = function(use_block_header)
+    if use_block_header ~= nil then
+        use_block_header = true
+    end
+
+    local comments = {
+        comment_start = use_block_header and "/*" or nil,
+        comment = use_block_header and "*" or "//",
+        comment_end = use_block_header and "*/" or nil,
+    }
+    return comments
+end
+languages.ruby = function(use_block_header)
+    if use_block_header ~= nil then
+        use_block_header = true
+    end
+
+    local comments = {
+        comment_start = use_block_header and "=begin" or nil,
         comment = "#",
-        comment_end = "=cut",
+        comment_end = use_block_header and "=end" or nil,
     }
     return comments
 end
-languages.typescript = function()
+languages.kotlin = function(use_block_header)
+    if use_block_header ~= nil then
+        use_block_header = true
+    end
+
     local comments = {
-        comment_start = "/*",
-        comment = "*",
-        comment_end = "*/",
+        comment_start = use_block_header and "/*" or nil,
+        comment = use_block_header and "*" or "//",
+        comment_end = use_block_header and "*/" or nil,
     }
     return comments
 end
-languages.coffeescript = function()
+languages.scala = function(use_block_header)
+    if use_block_header ~= nil then
+        use_block_header = true
+    end
+
     local comments = {
-        comment_start = "###",
+        comment_start = use_block_header and "/*" or nil,
+        comment = use_block_header and "*" or "//",
+        comment_end = use_block_header and "*/" or nil,
+    }
+    return comments
+end
+languages.go = function(use_block_header)
+    if use_block_header ~= nil then
+        use_block_header = true
+    end
+
+    local comments = {
+        comment_start = use_block_header and "/*" or nil,
+        comment = use_block_header and "*" or "//",
+        comment_end = use_block_header and "*/" or nil,
+    }
+    return comments
+end
+languages.rust = function(use_block_header)
+    if use_block_header ~= nil then
+        use_block_header = true
+    end
+
+    local comments = {
+        comment_start = use_block_header and "/*" or nil,
+        comment = use_block_header and "*" or "//",
+        comment_end = use_block_header and "*/" or nil,
+    }
+    return comments
+end
+languages.php = function(use_block_header)
+    if use_block_header ~= nil then
+        use_block_header = true
+    end
+
+    local comments = {
+        comment_start = use_block_header and "/*" or nil,
+        comment = use_block_header and "*" or "//",
+        comment_end = use_block_header and "*/" or nil,
+    }
+    return comments
+end
+languages.shell = function(_)
+    local comments = {
+        comment_start = nil,
         comment = "#",
-        comment_end = "###",
+        comment_end = nil,
     }
     return comments
 end
-languages.groovy = function()
+languages.haskell = function(use_block_header)
+    if use_block_header ~= nil then
+        use_block_header = true
+    end
+
     local comments = {
-        comment_start = "/*",
-        comment = "*",
-        comment_end = "*/",
+        comment_start = use_block_header and "{-" or nil,
+        comment = "--",
+        comment_end = use_block_header and "-}" or nil,
     }
     return comments
 end
-languages.dart = function()
+languages.perl = function(use_block_header)
+    if use_block_header ~= nil then
+        use_block_header = true
+    end
+
     local comments = {
-        comment_start = "/*",
-        comment = "*",
-        comment_end = "*/",
+        comment_start = use_block_header and "=pod" or nil,
+        comment = "#",
+        comment_end = use_block_header and "=cut" or nil,
     }
     return comments
 end
-languages.r = function()
+languages.typescript = function(use_block_header)
+    if use_block_header ~= nil then
+        use_block_header = true
+    end
+
+    local comments = {
+        comment_start = use_block_header and "/*" or nil,
+        comment = use_block_header and "*" or "//",
+        comment_end = use_block_header and "*/" or nil,
+    }
+    return comments
+end
+languages.coffeescript = function(use_block_header)
+    if use_block_header ~= nil then
+        use_block_header = true
+    end
+
+    local comments = {
+        comment_start = use_block_header and "###" or nil,
+        comment = "#",
+        comment_end = use_block_header and "###" or nil,
+    }
+    return comments
+end
+languages.groovy = function(use_block_header)
+    if use_block_header ~= nil then
+        use_block_header = true
+    end
+
+    local comments = {
+        comment_start = use_block_header and "/*" or nil,
+        comment = use_block_header and "*" or "//",
+        comment_end = use_block_header and "*/" or nil,
+    }
+    return comments
+end
+languages.dart = function(use_block_header)
+    if use_block_header ~= nil then
+        use_block_header = true
+    end
+
+    local comments = {
+        comment_start = use_block_header and "/*" or nil,
+        comment = use_block_header and "*" or "//",
+        comment_end = use_block_header and "*/" or nil,
+    }
+    return comments
+end
+languages.r = function(_)
     local comments = {
         comment_start = nil,
         comment = "#",

--- a/lua/languages.lua
+++ b/lua/languages.lua
@@ -1,6 +1,6 @@
 local languages = {}
 languages.cpp = function(use_block_header)
-    if use_block_header ~= nil then
+    if use_block_header == nil then
         use_block_header = true
     end
 
@@ -20,7 +20,7 @@ languages.python = function(_)
     return comments
 end
 languages.lua = function(use_block_header)
-    if use_block_header ~= nil then
+    if use_block_header == nil then
         use_block_header = true
     end
 
@@ -32,7 +32,7 @@ languages.lua = function(use_block_header)
     return comments
 end
 languages.java = function(use_block_header)
-    if use_block_header ~= nil then
+    if use_block_header == nil then
         use_block_header = true
     end
 
@@ -44,7 +44,7 @@ languages.java = function(use_block_header)
     return comments
 end
 languages.javascript = function(use_block_header)
-    if use_block_header ~= nil then
+    if use_block_header == nil then
         use_block_header = true
     end
 
@@ -56,7 +56,7 @@ languages.javascript = function(use_block_header)
     return comments
 end
 languages.csharp = function(use_block_header)
-    if use_block_header ~= nil then
+    if use_block_header == nil then
         use_block_header = true
     end
 
@@ -68,7 +68,7 @@ languages.csharp = function(use_block_header)
     return comments
 end
 languages.swift = function(use_block_header)
-    if use_block_header ~= nil then
+    if use_block_header == nil then
         use_block_header = true
     end
 
@@ -80,7 +80,7 @@ languages.swift = function(use_block_header)
     return comments
 end
 languages.ruby = function(use_block_header)
-    if use_block_header ~= nil then
+    if use_block_header == nil then
         use_block_header = true
     end
 
@@ -92,7 +92,7 @@ languages.ruby = function(use_block_header)
     return comments
 end
 languages.kotlin = function(use_block_header)
-    if use_block_header ~= nil then
+    if use_block_header == nil then
         use_block_header = true
     end
 
@@ -104,7 +104,7 @@ languages.kotlin = function(use_block_header)
     return comments
 end
 languages.scala = function(use_block_header)
-    if use_block_header ~= nil then
+    if use_block_header == nil then
         use_block_header = true
     end
 
@@ -116,7 +116,7 @@ languages.scala = function(use_block_header)
     return comments
 end
 languages.go = function(use_block_header)
-    if use_block_header ~= nil then
+    if use_block_header == nil then
         use_block_header = true
     end
 
@@ -128,7 +128,7 @@ languages.go = function(use_block_header)
     return comments
 end
 languages.rust = function(use_block_header)
-    if use_block_header ~= nil then
+    if use_block_header == nil then
         use_block_header = true
     end
 
@@ -140,7 +140,7 @@ languages.rust = function(use_block_header)
     return comments
 end
 languages.php = function(use_block_header)
-    if use_block_header ~= nil then
+    if use_block_header == nil then
         use_block_header = true
     end
 
@@ -160,7 +160,7 @@ languages.shell = function(_)
     return comments
 end
 languages.haskell = function(use_block_header)
-    if use_block_header ~= nil then
+    if use_block_header == nil then
         use_block_header = true
     end
 
@@ -172,7 +172,7 @@ languages.haskell = function(use_block_header)
     return comments
 end
 languages.perl = function(use_block_header)
-    if use_block_header ~= nil then
+    if use_block_header == nil then
         use_block_header = true
     end
 
@@ -184,7 +184,7 @@ languages.perl = function(use_block_header)
     return comments
 end
 languages.typescript = function(use_block_header)
-    if use_block_header ~= nil then
+    if use_block_header == nil then
         use_block_header = true
     end
 
@@ -196,7 +196,7 @@ languages.typescript = function(use_block_header)
     return comments
 end
 languages.coffeescript = function(use_block_header)
-    if use_block_header ~= nil then
+    if use_block_header == nil then
         use_block_header = true
     end
 
@@ -208,7 +208,7 @@ languages.coffeescript = function(use_block_header)
     return comments
 end
 languages.groovy = function(use_block_header)
-    if use_block_header ~= nil then
+    if use_block_header == nil then
         use_block_header = true
     end
 
@@ -220,7 +220,7 @@ languages.groovy = function(use_block_header)
     return comments
 end
 languages.dart = function(use_block_header)
-    if use_block_header ~= nil then
+    if use_block_header == nil then
         use_block_header = true
     end
 

--- a/lua/languages.lua
+++ b/lua/languages.lua
@@ -1,243 +1,150 @@
 local languages = {}
-languages.cpp = function(use_block_header)
-    if use_block_header == nil then
-        use_block_header = true
-    end
 
-    local comments = {
-        comment_start = use_block_header and "/*" or nil,
-        comment = use_block_header and "*" or "//",
-        comment_end = use_block_header and "*/" or nil,
+languages.cpp = function()
+    return {
+        block = { start = "/*", line = "*", ["end"] = "*/" },
+        line = { start = nil, line = "//", ["end"] = nil },
     }
-    return comments
 end
-languages.python = function(_)
-    local comments = {
-        comment_start = nil,
-        comment = "#",
-        comment_end = nil,
-    }
-    return comments
-end
-languages.lua = function(use_block_header)
-    if use_block_header == nil then
-        use_block_header = true
-    end
 
-    local comments = {
-        comment_start = use_block_header and "--[[" or nil,
-        comment = "--",
-        comment_end = use_block_header and "--]]" or nil,
+languages.python = function()
+    return {
+        block = nil,
+        line = { start = nil, line = "#", ["end"] = nil },
     }
-    return comments
 end
-languages.java = function(use_block_header)
-    if use_block_header == nil then
-        use_block_header = true
-    end
 
-    local comments = {
-        comment_start = use_block_header and "/*" or nil,
-        comment = use_block_header and "*" or "//",
-        comment_end = use_block_header and "*/" or nil,
+languages.lua = function()
+    return {
+        block = { start = "--[[", line = "--", ["end"] = "]]" },
+        line = { start = nil, line = "--", ["end"] = nil },
     }
-    return comments
 end
-languages.javascript = function(use_block_header)
-    if use_block_header == nil then
-        use_block_header = true
-    end
 
-    local comments = {
-        comment_start = use_block_header and "/*" or nil,
-        comment = use_block_header and "*" or "//",
-        comment_end = use_block_header and "*/" or nil,
+languages.java = function()
+    return {
+        block = { start = "/*", line = "*", ["end"] = "*/" },
+        line = { start = nil, line = "//", ["end"] = nil },
     }
-    return comments
 end
-languages.csharp = function(use_block_header)
-    if use_block_header == nil then
-        use_block_header = true
-    end
 
-    local comments = {
-        comment_start = use_block_header and "/*" or nil,
-        comment = use_block_header and "*" or "//",
-        comment_end = use_block_header and "*/" or nil,
+languages.javascript = function()
+    return {
+        block = { start = "/*", line = "*", ["end"] = "*/" },
+        line = { start = nil, line = "//", ["end"] = nil },
     }
-    return comments
 end
-languages.swift = function(use_block_header)
-    if use_block_header == nil then
-        use_block_header = true
-    end
 
-    local comments = {
-        comment_start = use_block_header and "/*" or nil,
-        comment = use_block_header and "*" or "//",
-        comment_end = use_block_header and "*/" or nil,
+languages.csharp = function()
+    return {
+        block = { start = "/*", line = "*", ["end"] = "*/" },
+        line = { start = nil, line = "//", ["end"] = nil },
     }
-    return comments
 end
-languages.ruby = function(use_block_header)
-    if use_block_header == nil then
-        use_block_header = true
-    end
 
-    local comments = {
-        comment_start = use_block_header and "=begin" or nil,
-        comment = "#",
-        comment_end = use_block_header and "=end" or nil,
+languages.swift = function()
+    return {
+        block = { start = "/*", line = "*", ["end"] = "*/" },
+        line = { start = nil, line = "//", ["end"] = nil },
     }
-    return comments
 end
-languages.kotlin = function(use_block_header)
-    if use_block_header == nil then
-        use_block_header = true
-    end
 
-    local comments = {
-        comment_start = use_block_header and "/*" or nil,
-        comment = use_block_header and "*" or "//",
-        comment_end = use_block_header and "*/" or nil,
+languages.ruby = function()
+    return {
+        block = { start = "=begin", line = "#", ["end"] = "=end" },
+        line = { start = nil, line = "#", ["end"] = nil },
     }
-    return comments
 end
-languages.scala = function(use_block_header)
-    if use_block_header == nil then
-        use_block_header = true
-    end
 
-    local comments = {
-        comment_start = use_block_header and "/*" or nil,
-        comment = use_block_header and "*" or "//",
-        comment_end = use_block_header and "*/" or nil,
+languages.kotlin = function()
+    return {
+        block = { start = "/*", line = "*", ["end"] = "*/" },
+        line = { start = nil, line = "//", ["end"] = nil },
     }
-    return comments
 end
-languages.go = function(use_block_header)
-    if use_block_header == nil then
-        use_block_header = true
-    end
 
-    local comments = {
-        comment_start = use_block_header and "/*" or nil,
-        comment = use_block_header and "*" or "//",
-        comment_end = use_block_header and "*/" or nil,
+languages.scala = function()
+    return {
+        block = { start = "/*", line = "*", ["end"] = "*/" },
+        line = { start = nil, line = "//", ["end"] = nil },
     }
-    return comments
 end
-languages.rust = function(use_block_header)
-    if use_block_header == nil then
-        use_block_header = true
-    end
 
-    local comments = {
-        comment_start = use_block_header and "/*" or nil,
-        comment = use_block_header and "*" or "//",
-        comment_end = use_block_header and "*/" or nil,
+languages.go = function()
+    return {
+        block = { start = "/*", line = "*", ["end"] = "*/" },
+        line = { start = nil, line = "//", ["end"] = nil },
     }
-    return comments
 end
-languages.php = function(use_block_header)
-    if use_block_header == nil then
-        use_block_header = true
-    end
 
-    local comments = {
-        comment_start = use_block_header and "/*" or nil,
-        comment = use_block_header and "*" or "//",
-        comment_end = use_block_header and "*/" or nil,
+languages.rust = function()
+    return {
+        block = { start = "/*", line = "*", ["end"] = "*/" },
+        line = { start = nil, line = "//", ["end"] = nil },
     }
-    return comments
 end
-languages.shell = function(_)
-    local comments = {
-        comment_start = nil,
-        comment = "#",
-        comment_end = nil,
-    }
-    return comments
-end
-languages.haskell = function(use_block_header)
-    if use_block_header == nil then
-        use_block_header = true
-    end
 
-    local comments = {
-        comment_start = use_block_header and "{-" or nil,
-        comment = "--",
-        comment_end = use_block_header and "-}" or nil,
+languages.php = function()
+    return {
+        block = { start = "/*", line = "*", ["end"] = "*/" },
+        line = { start = nil, line = "//", ["end"] = nil },
     }
-    return comments
 end
-languages.perl = function(use_block_header)
-    if use_block_header == nil then
-        use_block_header = true
-    end
 
-    local comments = {
-        comment_start = use_block_header and "=pod" or nil,
-        comment = "#",
-        comment_end = use_block_header and "=cut" or nil,
+languages.shell = function()
+    return {
+        block = nil,
+        line = { start = nil, line = "#", ["end"] = nil },
     }
-    return comments
 end
-languages.typescript = function(use_block_header)
-    if use_block_header == nil then
-        use_block_header = true
-    end
 
-    local comments = {
-        comment_start = use_block_header and "/*" or nil,
-        comment = use_block_header and "*" or "//",
-        comment_end = use_block_header and "*/" or nil,
+languages.haskell = function()
+    return {
+        block = { start = "{-", line = "--", ["end"] = "-}" },
+        line = { start = nil, line = "--", ["end"] = nil },
     }
-    return comments
 end
-languages.coffeescript = function(use_block_header)
-    if use_block_header == nil then
-        use_block_header = true
-    end
 
-    local comments = {
-        comment_start = use_block_header and "###" or nil,
-        comment = "#",
-        comment_end = use_block_header and "###" or nil,
+languages.perl = function()
+    return {
+        block = { start = "=begin", line = "#", ["end"] = "=cut" },
+        line = { start = nil, line = "#", ["end"] = nil },
     }
-    return comments
 end
-languages.groovy = function(use_block_header)
-    if use_block_header == nil then
-        use_block_header = true
-    end
 
-    local comments = {
-        comment_start = use_block_header and "/*" or nil,
-        comment = use_block_header and "*" or "//",
-        comment_end = use_block_header and "*/" or nil,
+languages.typescript = function()
+    return {
+        block = { start = "/*", line = "*", ["end"] = "*/" },
+        line = { start = nil, line = "//", ["end"] = nil },
     }
-    return comments
 end
-languages.dart = function(use_block_header)
-    if use_block_header == nil then
-        use_block_header = true
-    end
 
-    local comments = {
-        comment_start = use_block_header and "/*" or nil,
-        comment = use_block_header and "*" or "//",
-        comment_end = use_block_header and "*/" or nil,
+languages.coffeescript = function()
+    return {
+        block = { start = "###", line = "#", ["end"] = "###" },
+        line = { start = nil, line = "#", ["end"] = nil },
     }
-    return comments
 end
-languages.r = function(_)
-    local comments = {
-        comment_start = nil,
-        comment = "#",
-        comment_end = nil,
+
+languages.groovy = function()
+    return {
+        block = { start = "/*", line = "*", ["end"] = "*/" },
+        line = { start = nil, line = "//", ["end"] = nil },
     }
-    return comments
+end
+
+languages.dart = function()
+    return {
+        block = { start = "/*", line = "*", ["end"] = "*/" },
+        line = { start = nil, line = "//", ["end"] = nil },
+    }
+end
+
+languages.r = function()
+    return {
+        block = nil,
+        line = { start = nil, line = "#", ["end"] = nil },
+    }
 end
 
 return languages

--- a/lua/languages.lua
+++ b/lua/languages.lua
@@ -1,5 +1,9 @@
 local languages = {}
 languages.cpp = function(use_block_header)
+    if use_block_header ~= nil then
+        use_block_header = true
+    end
+
     local comments = {
         comment_start = use_block_header and "/*" or nil,
         comment = use_block_header and "*" or "//",

--- a/lua/languages.lua
+++ b/lua/languages.lua
@@ -16,7 +16,7 @@ end
 
 languages.lua = function()
     return {
-        block = { start = "--[[", line = "--", ["end"] = "]]" },
+        block = { start = "--[[", line = "--", ["end"] = "--]]" },
         line = { start = nil, line = "--", ["end"] = nil },
     }
 end

--- a/tests/header/header_spec.lua
+++ b/tests/header/header_spec.lua
@@ -10,11 +10,20 @@ local function get_modified_date(buffer)
 end
 
 local function get_buffer_without_date(buffer, comments, constants)
+    local style
+    if header.config.use_block_header and comments.block and comments.block.start then
+        style = comments.block
+    elseif comments.line and comments.line.line then
+        style = comments.line
+    else
+        style = comments.block or comments.line
+    end
+
     result = {}
     for _, line in ipairs(buffer) do
         if
-            not line:match("^%" .. comments.comment .. " " .. constants.date_created)
-            and not line:match("^%" .. comments.comment .. " " .. constants.date_modified)
+            not line:match("^%" .. style.line .. " " .. constants.date_created)
+            and not line:match("^%" .. style.line .. " " .. constants.date_modified)
         then
             table.insert(result, line)
         end
@@ -23,19 +32,28 @@ local function get_buffer_without_date(buffer, comments, constants)
 end
 
 local function build_minimal_expected_comments(file_name, comments, header)
+    local style
+    if header.config.use_block_header and comments.block and comments.block.start then
+        style = comments.block
+    elseif comments.line and comments.line.line then
+        style = comments.line
+    else
+        style = comments.block or comments.line
+    end
+
     local result = {
-        comments.comment .. " " .. header.constants.file_name .. " " .. file_name,
-        comments.comment .. " " .. header.config.line_separator,
+        style.line .. " " .. header.constants.file_name .. " " .. file_name,
+        style.line .. " " .. header.config.line_separator,
         "",
         file_name,
     }
 
-    if comments.comment_start ~= nil then
+    if style.start and style["end"] then
         result = {
-            comments.comment_start,
-            comments.comment .. " " .. header.constants.file_name .. " " .. file_name,
-            comments.comment .. " " .. header.config.line_separator,
-            comments.comment_end,
+            style.start,
+            style.line .. " " .. header.constants.file_name .. " " .. file_name,
+            style.line .. " " .. header.config.line_separator,
+            style["end"],
             "",
             file_name,
         }
@@ -44,25 +62,34 @@ local function build_minimal_expected_comments(file_name, comments, header)
 end
 
 local function build_extended_expected_comments(file_name, comments, constants, config)
+    local style
+    if config.use_block_header and comments.block and comments.block.start then
+        style = comments.block
+    elseif comments.line and comments.line.line then
+        style = comments.line
+    else
+        style = comments.block or comments.line
+    end
+
     local result = {
-        comments.comment .. " " .. constants.file_name .. " " .. file_name,
-        comments.comment .. " " .. constants.project .. " " .. config.project,
-        comments.comment .. " " .. constants.author .. " " .. config.author,
-        comments.comment .. " " .. config.line_separator,
-        comments.comment .. " " .. config.copyright_text,
+        style.line .. " " .. constants.file_name .. " " .. file_name,
+        style.line .. " " .. constants.project .. " " .. config.project,
+        style.line .. " " .. constants.author .. " " .. config.author,
+        style.line .. " " .. config.line_separator,
+        style.line .. " " .. config.copyright_text,
         "",
         file_name,
     }
 
-    if comments.comment_start ~= nil then
+    if style.start and style["end"] then
         result = {
-            comments.comment_start,
-            comments.comment .. " " .. constants.file_name .. " " .. file_name,
-            comments.comment .. " " .. constants.project .. " " .. config.project,
-            comments.comment .. " " .. constants.author .. " " .. config.author,
-            comments.comment .. " " .. config.line_separator,
-            comments.comment .. " " .. config.copyright_text,
-            comments.comment_end,
+            style.start,
+            style.line .. " " .. constants.file_name .. " " .. file_name,
+            style.line .. " " .. constants.project .. " " .. config.project,
+            style.line .. " " .. constants.author .. " " .. config.author,
+            style.line .. " " .. config.line_separator,
+            style.line .. " " .. config.copyright_text,
+            style["end"],
             "",
             file_name,
         }
@@ -127,7 +154,7 @@ describe("add_headers", function()
 
             local buffer = vim.api.nvim_buf_get_lines(0, 0, -1, false)
 
-            local comments = v(header.config.use_block_header)
+            local comments = v()
 
             local expected = build_minimal_expected_comments(file_name, comments, header)
 
@@ -148,7 +175,7 @@ describe("add_headers", function()
 
             local buffer = vim.api.nvim_buf_get_lines(0, 0, -1, false)
 
-            local comments = v(header.config.use_block_header)
+            local comments = v()
 
             local expected = build_minimal_expected_comments(file_name, comments, header)
 
@@ -183,7 +210,7 @@ describe("add_headers", function()
 
             local buffer = vim.api.nvim_buf_get_lines(0, 0, -1, false)
 
-            local comments = v(config.use_block_header)
+            local comments = v()
             local expected = build_extended_expected_comments(file_name, comments, header.constants, config)
 
             local buffer_without_date = get_buffer_without_date(buffer, comments, header.constants)
@@ -201,7 +228,7 @@ describe("add_headers", function()
 
             header.add_headers()
             local buffer = vim.api.nvim_buf_get_lines(0, 0, -1, false)
-            local comments = v(header.config.use_block_header)
+            local comments = v()
 
             local config = {
                 file_name = true,
@@ -268,8 +295,8 @@ describe("add_headers", function()
 
             local buffer = vim.api.nvim_buf_get_lines(0, 0, -1, false)
 
-            local single_commented = v(header.config.use_block_header)
-            local block_commented = v(comparison_config.use_block_header)
+            local single_commented = v()
+            local block_commented = v()
 
             local expected = build_extended_expected_comments(file_name, single_commented, header.constants, config)
             local buffer_without_date = get_buffer_without_date(buffer, single_commented, header.constants)


### PR DESCRIPTION
Changes:

- Adds the config option `use_block_header` to optionally prefer the block-style comment in a given language (if `true`) over the single-line comment (if `false`).

	By default, the value is `true` to maintain the original behaviour, which preferred block-style comments over multiple single-line comments.

- Adds a test to check that the above is actually working (with an edge case for languages that only have one type of comment i.e. Python).