### PR TITLE
[Feature] Add `allow_autocmds` config flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The script comes with the following defaults:
 
 ```lua
 {
+    allow_autocmds = true,
     file_name = true,
     author = nil,
     project = nil,
@@ -64,6 +65,7 @@ Example:
 
 ```lua
 require("header").setup({
+    allow_autocmds = true,
     file_name = true,
     author = "Foo",
     project = "header.nvim",

--- a/lua/header.lua
+++ b/lua/header.lua
@@ -6,6 +6,7 @@ header.header_size = 9
 header.selected_license_file = nil
 
 header.config = {
+    allow_autocmds = true,
     file_name = true,
     author = nil,
     project = nil,
@@ -520,6 +521,7 @@ end
 
 header.reset = function()
     header.config = {
+        allow_autocmds = true,
         file_name = true,
         author = nil,
         project = nil,

--- a/tests/header/header_spec.lua
+++ b/tests/header/header_spec.lua
@@ -103,6 +103,7 @@ describe("setup", function()
     end)
     it("setup with default configs", function()
         local expected = {
+            allow_autocmds = true,
             file_name = true,
             author = nil,
             project = nil,
@@ -121,6 +122,7 @@ describe("setup", function()
 
     it("setup with custom configs", function()
         local expected = {
+            allow_autocmds = false,
             file_name = true,
             author = "test_author",
             project = "test_project",


### PR DESCRIPTION
Adds a new flag `allow_autocmds` to the module config so that users can optionally enable/disable calls to user-facing methods on the `header` table depending on the value. Does not actually effect internal logic, meaning that if `allow_autocmds` is `true` but a call to `add_headers` is not gated behind that being the case, `add_headers` will still add the headers. This is purely for custom user functionality, so it can be enabled/disabled on a per-project basis.

For example, consider the following autocmd:

```lua
autocmd("BufNewFile", {
  pattern = "*",
  callback = function()
    local header = require("header")
    if not header then
      vim.notify("Could not automatically add header to new file: header module couldn't be found")
      return
    end

	-- this code will only get called if `allow_autocmds == true`
    if header.config.allow_autocmds then
      local original_fmt = header.config.date_created_fmt
      local now = os.date(header.config.date_created_fmt, os.time())

      -- force add_headers to use the current datetime, otherwise it will show 1970-01-01
      header.config.date_created_fmt = now
      header.add_headers()

      header.config.date_created_fmt = original_fmt -- restore the original format
    end

	-- this code will be called regardless
    local original_fmt = header.config.date_created_fmt
    local now = os.date(header.config.date_created_fmt, os.time())

    -- force add_headers to use the current datetime, otherwise it will show 1970-01-01
    header.config.date_created_fmt = now
    header.add_headers()

    header.config.date_created_fmt = original_fmt -- restore the original format
  end,
  group = copyright_group,
  desc = "Add copyright header to new files",
})
```

Closes #20.