### PR TITLE
feat: apply token replacement to all headers

### DIFF
--- a/lua/header/util.lua
+++ b/lua/header/util.lua
@@ -1,6 +1,6 @@
 local M = {}
 
-function M.replace_token(str, token, value)
+local function replace_token(str, token, value)
     local pattern = "{{%s*" .. token .. "%s*}}"
     return string.gsub(str, pattern, value or "")
 end
@@ -11,6 +11,13 @@ function M.string_to_table(str)
         table.insert(lines, line)
     end
     return lines
+end
+
+function M.replace_all_tokens(license_text, header)
+    license_text = replace_token(license_text, "project", header.config.project)
+    license_text = replace_token(license_text, "organization", header.config.author)
+    license_text = replace_token(license_text, "year", os.date("%Y"))
+    return license_text
 end
 
 function M.escape_special_characters(pattern)


### PR DESCRIPTION
this also substitutes all placeholders (project, organization, year) in license/notice files