### PR TITLE
feat: add file_full_path option to use absolute path instead of filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The script comes with the following defaults:
 {
     allow_autocmds = true,
     file_name = true,
+    file_full_path = false,
     author = nil,
     project = nil,
     date_created = true,
@@ -74,6 +75,7 @@ Example:
 require("header").setup({
     allow_autocmds = true,
     file_name = true,
+    file_full_path = false,
     author = "Foo",
     project = "header.nvim",
     date_created = true,
@@ -133,6 +135,7 @@ The default configuration can be overwritten by a local project `.header.nvim` f
 {
   "allow_autocmds": true,
   "file_name": true,
+  "file_full_path": false,
   "author": "Your Name",
   "project": "Your Project",
   "date_created": true,

--- a/lua/header/config.lua
+++ b/lua/header/config.lua
@@ -3,6 +3,7 @@ local M = {}
 M.defaults = {
     allow_autocmds = true,
     file_name = true,
+    file_full_path = false,
     author = nil,
     project = nil,
     date_created = true,

--- a/lua/header/core.lua
+++ b/lua/header/core.lua
@@ -70,7 +70,13 @@ function M.add_headers(header)
             return
         end
 
-        local file = vim.fn.expand("%:t")
+        local file
+        if header.config.file_full_path then
+            file = vim.fn.expand("%:p") -- full path
+        else
+            file = vim.fn.expand("%:t") -- tail only (original behaviour)
+        end
+
         local created = os.date(header.config.date_created_fmt, vim.fn.getftime(vim.fn.expand("%")))
 
         local hdrs = {}

--- a/lua/header/core.lua
+++ b/lua/header/core.lua
@@ -72,9 +72,9 @@ function M.add_headers(header)
 
         local file
         if header.config.file_full_path then
-            file = vim.fn.expand("%:p") -- full path
+            file = vim.fn.expand("%:p")
         else
-            file = vim.fn.expand("%:t") -- tail only (original behaviour)
+            file = vim.fn.expand("%:t")
         end
 
         local created = os.date(header.config.date_created_fmt, vim.fn.getftime(vim.fn.expand("%")))

--- a/tests/header/add_headers_spec.lua
+++ b/tests/header/add_headers_spec.lua
@@ -331,4 +331,45 @@ describe("add_headers", function()
             assert.are.same(expected, buffer_without_date)
         end
     end)
+
+    it("should use full path when file_full_path is true", function()
+        for k, v in pairs(filetypes) do
+            vim.api.nvim_buf_set_lines(0, 0, -1, false, {})
+            local file_name = "main." .. k
+            local full_path = "/home/user/projects/myproject/" .. file_name
+            vim.fn.setline(1, file_name)
+            vim.api.nvim_buf_set_name(0, full_path)
+
+            header.setup({ file_full_path = true })
+            header.add_headers()
+
+            local buffer = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+            local comments = v()
+            local expected = build_minimal_expected_comments(full_path, comments)
+            expected[#expected] = file_name
+            local buffer_without_date = get_buffer_without_date(buffer, comments, header.constants)
+
+            assert.are.same(expected, buffer_without_date)
+        end
+    end)
+
+    it("should use filename only when file_full_path is false (default)", function()
+        for k, v in pairs(filetypes) do
+            vim.api.nvim_buf_set_lines(0, 0, -1, false, {})
+            local file_name = "main." .. k
+            local full_path = "/home/user/projects/myproject/" .. file_name
+            vim.fn.setline(1, file_name)
+            vim.api.nvim_buf_set_name(0, full_path)
+
+            header.setup({ file_full_path = false })
+            header.add_headers()
+
+            local buffer = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+            local comments = v()
+            local expected = build_minimal_expected_comments(file_name, comments)
+            local buffer_without_date = get_buffer_without_date(buffer, comments, header.constants)
+
+            assert.are.same(expected, buffer_without_date)
+        end
+    end)
 end)

--- a/tests/header/setup_spec.lua
+++ b/tests/header/setup_spec.lua
@@ -7,6 +7,7 @@ describe("setup", function()
         local expected = {
             allow_autocmds = true,
             file_name = true,
+            file_full_path = false,
             author = nil,
             project = nil,
             date_created = true,
@@ -27,6 +28,7 @@ describe("setup", function()
         local expected = {
             allow_autocmds = false,
             file_name = true,
+            file_full_path = false,
             author = "test_author",
             project = "test_project",
             date_created = true,


### PR DESCRIPTION
## feat: add `file_full_path` option for absolute file path in header

### What does this PR do?

Adds a new `file_full_path` option that allows using the absolute file path instead of just the filename in the header.

### Changes

- `config.lua`: new option `file_full_path = false` added to defaults
- `core.lua`: `vim.fn.expand("%:p")` used when `file_full_path = true`, otherwise original behaviour (`%:t`) is preserved

### Usage

```lua
require("header").setup({
  file_name = true,
  file_full_path = true,   -- new option
})
```

### Example

With `file_full_path = false` (default, no breaking change):
```
-- File name: init.lua
```

With `file_full_path = true`:
```
-- File name: /home/user/projects/myproject/lua/config/init.lua
```

### Notes

- Default is `false` → fully backwards compatible, no breaking change
- `file_name` must still be `true` for the path to appear in the header