### PR TITLE
feat: add custom label support via `*_label` config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ The script comes with the following defaults:
     copyright_text = nil,
     license_from_file = false,
     author_from_git = false,
+    file_name_label = nil,
+    author_label = nil,
+    project_label = nil,
+    date_created_label = nil,
+    date_modified_label = nil,
 }
 ```
 
@@ -92,6 +97,11 @@ require("header").setup({
     },
     license_from_file = false,
     author_from_git = false,
+    file_name_label = nil,
+    author_label = nil,
+    project_label = nil,
+    date_created_label = nil,
+    date_modified_label = nil,
 })
 ```
 
@@ -127,6 +137,22 @@ The following file names are recognized:
 - This feature is useful when working on open-source projects that already include a license file.
 - License headers inserted from a file will be commented automatically based on the current filetype.
 - If you want to override the selected license file or insert a different one later, you can disable and re-enable the plugin, or restart Neovim.
+
+### Custom field labels
+
+To override the default label text for any header field, use the corresponding `*_label` option:
+
+```lua
+require("header").setup({
+    file_name_label = "File:",
+    author_label = "Author:",
+    project_label = "Project:",
+    date_created_label = "Created:",
+    date_modified_label = "Modified:",
+})
+```
+
+When a `*_label` option is set to `nil` (the default), the built-in label is used.
 
 ### Project specific configuration
 

--- a/README.md
+++ b/README.md
@@ -144,13 +144,14 @@ To override the default label text for any header field, use the corresponding `
 
 ```lua
 require("header").setup({
-    file_name_label = "File:",
-    author_label = "Author:",
-    project_label = "Project:",
-    date_created_label = "Created:",
-    date_modified_label = "Modified:",
+    file_name_label = "File",
+    author_label = "Author",
+    project_label = "Project",
+    date_created_label = "Created",
+    date_modified_label = "Modified",
 })
 ```
+The `:` separator is appended automatically by the plugin.
 
 When a `*_label` option is set to `nil` (the default), the built-in label is used.
 

--- a/lua/header/config.lua
+++ b/lua/header/config.lua
@@ -31,10 +31,12 @@ M.constants = {
 }
 
 function M.get_label(config, constants, field)
-    local label = config[field .. "_label"] or constants[field]
+function M.get_label(config, constants, field)
+    local label = config[field .. "_label"]
+        or constants[field]
+
     return label .. ":"
 end
-
 function M.read_config_file()
     local f = io.open(".header.nvim", "r")
     if not f then

--- a/lua/header/config.lua
+++ b/lua/header/config.lua
@@ -23,15 +23,16 @@ M.defaults = {
 }
 
 M.constants = {
-    file_name = "File name:",
-    date_created = "Date created:",
-    author = "Author:",
-    project = "Project:",
-    date_modified = "Date modified:",
+    file_name = "File name",
+    date_created = "Date created",
+    author = "Author",
+    project = "Project",
+    date_modified = "Date modified",
 }
 
 function M.get_label(config, constants, field)
-    return config[field .. "_label"] or constants[field]
+    local label = config[field .. "_label"] or constants[field]
+    return label .. ":"
 end
 
 function M.read_config_file()

--- a/lua/header/config.lua
+++ b/lua/header/config.lua
@@ -15,6 +15,11 @@ M.defaults = {
     copyright_text = nil,
     license_from_file = false,
     author_from_git = false,
+    file_name_label = nil,
+    date_created_label = nil,
+    author_label = nil,
+    project_label = nil,
+    date_modified_label = nil,
 }
 
 M.constants = {
@@ -24,6 +29,10 @@ M.constants = {
     project = "Project:",
     date_modified = "Date modified:",
 }
+
+function M.get_label(config, constants, field)
+    return config[field .. "_label"] or constants[field]
+end
 
 function M.read_config_file()
     local f = io.open(".header.nvim", "r")

--- a/lua/header/config.lua
+++ b/lua/header/config.lua
@@ -31,12 +31,10 @@ M.constants = {
 }
 
 function M.get_label(config, constants, field)
-function M.get_label(config, constants, field)
-    local label = config[field .. "_label"]
-        or constants[field]
-
+    local label = config[field .. "_label"] or constants[field]
     return label .. ":"
 end
+
 function M.read_config_file()
     local f = io.open(".header.nvim", "r")
     if not f then

--- a/lua/header/core.lua
+++ b/lua/header/core.lua
@@ -2,6 +2,7 @@ local comment_utils = require("header.comment_utils")
 local util = require("header.util")
 local license = require("header.license")
 local languages = require("header.languages")
+local config_mod = require("header.config")
 
 local M = {}
 
@@ -86,19 +87,30 @@ local function prepare_header_content(header, callback)
 
     local hdrs = {}
     if header.config.file_name then
-        table.insert(hdrs, header.constants.file_name .. " " .. file)
+        table.insert(hdrs, config_mod.get_label(header.config, header.constants, "file_name") .. " " .. file)
     end
     if header.config.project then
-        table.insert(hdrs, header.constants.project .. " " .. header.config.project)
+        table.insert(
+            hdrs,
+            config_mod.get_label(header.config, header.constants, "project") .. " " .. header.config.project
+        )
     end
     if header.config.author then
-        table.insert(hdrs, header.constants.author .. " " .. header.config.author)
+        table.insert(
+            hdrs,
+            config_mod.get_label(header.config, header.constants, "author") .. " " .. header.config.author
+        )
     end
     if header.config.date_created then
-        table.insert(hdrs, header.constants.date_created .. " " .. created)
+        table.insert(hdrs, config_mod.get_label(header.config, header.constants, "date_created") .. " " .. created)
     end
     if header.config.date_modified then
-        table.insert(hdrs, header.constants.date_modified .. " " .. os.date(header.config.date_modified_fmt))
+        table.insert(
+            hdrs,
+            config_mod.get_label(header.config, header.constants, "date_modified")
+                .. " "
+                .. os.date(header.config.date_modified_fmt)
+        )
     end
     if header.config.line_separator then
         table.insert(hdrs, header.config.line_separator)

--- a/tests/header/add_headers_spec.lua
+++ b/tests/header/add_headers_spec.lua
@@ -397,13 +397,13 @@ describe("add_header", function()
             vim.api.nvim_buf_set_name(0, file_name)
 
             header.setup({
-                file_name_label = "Datei:",
+                file_name_label = "Datei",
                 author = "test_author",
-                author_label = "Autor:",
+                author_label = "Autor",
                 project = "test_project",
-                project_label = "Projekt:",
-                date_created_label = "Erstellt:",
-                date_modified_label = "Geändert:",
+                project_label = "Projekt",
+                date_created_label = "Erstellt",
+                date_modified_label = "Geändert",
             })
 
             header.add_header()

--- a/tests/header/add_headers_spec.lua
+++ b/tests/header/add_headers_spec.lua
@@ -1,6 +1,7 @@
 require("plenary.reload").reload_module("header", true)
 local header = require("header")
 local languages = require("header.languages")
+local config_mod = require("header.config")
 
 local function get_buffer_without_date(buffer, comment_style, constants)
     local style
@@ -15,8 +16,8 @@ local function get_buffer_without_date(buffer, comment_style, constants)
     local result = {}
     for _, line in ipairs(buffer) do
         if
-            not line:match("^%" .. style.line .. " " .. constants.date_created)
-            and not line:match("^%" .. style.line .. " " .. constants.date_modified)
+            not line:match("^%" .. style.line .. " " .. config_mod.get_label(header.config, constants, "date_created"))
+            and not line:match("^%" .. style.line .. " " .. config_mod.get_label(header.config, constants, "date_modified"))
         then
             table.insert(result, line)
         end
@@ -35,7 +36,7 @@ local function build_minimal_expected_comments(file_name, comment_style)
     end
 
     local result = {
-        style.line .. " " .. header.constants.file_name .. " " .. file_name,
+        style.line .. " " .. header.config_mod.get_label(header.config, constants, "file_name") .. " " .. file_name,
         style.line .. " " .. header.config.line_separator,
         "",
         file_name,
@@ -44,7 +45,7 @@ local function build_minimal_expected_comments(file_name, comment_style)
     if style.start and style["end"] then
         result = {
             style.start,
-            style.line .. " " .. header.constants.file_name .. " " .. file_name,
+            style.line .. " " .. header.config_mod.get_label(header.config, constants, "file_name") .. " " .. file_name,
             style.line .. " " .. header.config.line_separator,
             style["end"],
             "",
@@ -85,9 +86,9 @@ local function build_extended_expected_comments(file_name, comment_style, consta
         table.insert(result, style.start)
     end
 
-    table.insert(result, style.line .. " " .. constants.file_name .. " " .. file_name)
-    table.insert(result, style.line .. " " .. constants.project .. " " .. config.project)
-    table.insert(result, style.line .. " " .. constants.author .. " " .. config.author)
+    table.insert(result, style.line .. " " .. config_mod.get_label(header.config, constants, "file_name") .. " " .. file_name)
+    table.insert(result, style.line .. " " .. config_mod.get_label(header.config, constants, "project") .. " " .. config.project)
+    table.insert(result, style.line .. " " .. config_mod.get_label(header.config, constants, "author") .. " " .. config.author)
     table.insert(result, style.line .. " " .. config.line_separator)
     append_copyright_lines(config.copyright_text)
 

--- a/tests/header/add_headers_spec.lua
+++ b/tests/header/add_headers_spec.lua
@@ -36,7 +36,7 @@ local function build_minimal_expected_comments(file_name, comment_style)
     end
 
     local result = {
-        style.line .. " " .. header.config_mod.get_label(header.config, constants, "file_name") .. " " .. file_name,
+        style.line .. " " .. config_mod.get_label(header.config, constants, "file_name") .. " " .. file_name,
         style.line .. " " .. header.config.line_separator,
         "",
         file_name,
@@ -45,7 +45,7 @@ local function build_minimal_expected_comments(file_name, comment_style)
     if style.start and style["end"] then
         result = {
             style.start,
-            style.line .. " " .. header.config_mod.get_label(header.config, constants, "file_name") .. " " .. file_name,
+            style.line .. " " .. config_mod.get_label(header.config, constants, "file_name") .. " " .. file_name,
             style.line .. " " .. header.config.line_separator,
             style["end"],
             "",

--- a/tests/header/add_headers_spec.lua
+++ b/tests/header/add_headers_spec.lua
@@ -67,7 +67,9 @@ local function build_extended_expected_comments(file_name, comment_style, consta
     local result = {}
 
     local function append_copyright_lines(text)
-        if not text then return end
+        if not text then
+            return
+        end
         if type(text) == "string" then
             for line in text:gmatch("[^\r\n]+") do
                 table.insert(result, style.line .. " " .. line)
@@ -79,7 +81,9 @@ local function build_extended_expected_comments(file_name, comment_style, consta
         end
     end
 
-    if style.start then table.insert(result, style.start) end
+    if style.start then
+        table.insert(result, style.start)
+    end
 
     table.insert(result, style.line .. " " .. constants.file_name .. " " .. file_name)
     table.insert(result, style.line .. " " .. constants.project .. " " .. config.project)
@@ -87,7 +91,9 @@ local function build_extended_expected_comments(file_name, comment_style, consta
     table.insert(result, style.line .. " " .. config.line_separator)
     append_copyright_lines(config.copyright_text)
 
-    if style["end"] then table.insert(result, style["end"]) end
+    if style["end"] then
+        table.insert(result, style["end"])
+    end
 
     table.insert(result, "")
     table.insert(result, file_name)
@@ -262,7 +268,12 @@ describe("add_header", function()
             assert.are.same(expected, buffer_without_date)
 
             -- Only test the difference if language actually has BOTH block and line comment_style
-            if lang.comment_style.line and lang.comment_style.line.line and lang.comment_style.block and lang.comment_style.block.start then
+            if
+                lang.comment_style.line
+                and lang.comment_style.line.line
+                and lang.comment_style.block
+                and lang.comment_style.block.start
+            then
                 expected =
                     build_extended_expected_comments(file_name, block_commented, header.constants, comparison_config)
                 assert.are.not_same(expected, buffer_without_date)
@@ -290,7 +301,7 @@ describe("add_header", function()
                 copyright_text = {
                     "Copyright (c) 2026 Your Name",
                     "Your Company",
-                    "All rights reserved."
+                    "All rights reserved.",
                 },
             }
             header.setup(config)
@@ -323,7 +334,7 @@ describe("add_header", function()
                 date_modified_fmt = "%Y-%m-%d %H:%M:%S",
                 line_separator = "------",
                 use_block_header = true,
-                copyright_text = "Copyright (c) 2026 Your Name\nYour Company\nAll rights reserved."
+                copyright_text = "Copyright (c) 2026 Your Name\nYour Company\nAll rights reserved.",
             }
 
             header.setup(config)
@@ -376,6 +387,47 @@ describe("add_header", function()
             local buffer_without_date = get_buffer_without_date(buffer, lang.comment_style, header.constants)
 
             assert.are.same(expected, buffer_without_date)
+        end
+    end)
+    it("should use custom labels when *_label options are set", function()
+        for _, ext in ipairs(get_all_extensions()) do
+            vim.api.nvim_buf_set_lines(0, 0, -1, false, {})
+            local file_name = "main." .. ext
+            vim.fn.setline(1, file_name)
+            vim.api.nvim_buf_set_name(0, file_name)
+
+            header.setup({
+                file_name_label = "Datei:",
+                author = "test_author",
+                author_label = "Autor:",
+                project = "test_project",
+                project_label = "Projekt:",
+                date_created_label = "Erstellt:",
+                date_modified_label = "Geändert:",
+            })
+
+            header.add_header()
+
+            local buffer = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+
+            local found_file_label = false
+            local found_author_label = false
+            local found_project_label = false
+            for _, line in ipairs(buffer) do
+                if line:find("Datei:", 1, true) then
+                    found_file_label = true
+                end
+                if line:find("Autor:", 1, true) then
+                    found_author_label = true
+                end
+                if line:find("Projekt:", 1, true) then
+                    found_project_label = true
+                end
+            end
+
+            assert.is_true(found_file_label)
+            assert.is_true(found_author_label)
+            assert.is_true(found_project_label)
         end
     end)
 end)

--- a/tests/header/add_headers_spec.lua
+++ b/tests/header/add_headers_spec.lua
@@ -36,7 +36,7 @@ local function build_minimal_expected_comments(file_name, comment_style)
     end
 
     local result = {
-        style.line .. " " .. config_mod.get_label(header.config, constants, "file_name") .. " " .. file_name,
+        style.line .. " " .. config_mod.get_label(header.config, header.constants, "file_name") .. " " .. file_name,
         style.line .. " " .. header.config.line_separator,
         "",
         file_name,
@@ -45,7 +45,7 @@ local function build_minimal_expected_comments(file_name, comment_style)
     if style.start and style["end"] then
         result = {
             style.start,
-            style.line .. " " .. config_mod.get_label(header.config, constants, "file_name") .. " " .. file_name,
+            style.line .. " " .. config_mod.get_label(header.config, header.constants, "file_name") .. " " .. file_name,
             style.line .. " " .. header.config.line_separator,
             style["end"],
             "",
@@ -86,7 +86,7 @@ local function build_extended_expected_comments(file_name, comment_style, consta
         table.insert(result, style.start)
     end
 
-    table.insert(result, style.line .. " " .. config_mod.get_label(header.config, constants, "file_name") .. " " .. file_name)
+    table.insert(result, style.line .. " " .. config_mod.get_label(header.config, header.constants, "file_name") .. " " .. file_name)
     table.insert(result, style.line .. " " .. config_mod.get_label(header.config, constants, "project") .. " " .. config.project)
     table.insert(result, style.line .. " " .. config_mod.get_label(header.config, constants, "author") .. " " .. config.author)
     table.insert(result, style.line .. " " .. config.line_separator)

--- a/tests/header/setup_spec.lua
+++ b/tests/header/setup_spec.lua
@@ -1,7 +1,9 @@
 local header = require("header")
 
 describe("setup", function()
-    before_each(function() header.reset() end)
+    before_each(function()
+        header.reset()
+    end)
 
     it("setup with default configs", function()
         local expected = {
@@ -19,6 +21,11 @@ describe("setup", function()
             copyright_text = nil,
             license_from_file = false,
             author_from_git = false,
+            file_name_label = nil,
+            date_created_label = nil,
+            author_label = nil,
+            project_label = nil,
+            date_modified_label = nil,
         }
         header.setup()
         assert.are.same(expected, header.config)
@@ -40,6 +47,11 @@ describe("setup", function()
             copyright_text = "test_copyright",
             license_from_file = false,
             author_from_git = false,
+            file_name_label = nil,
+            date_created_label = nil,
+            author_label = nil,
+            project_label = nil,
+            date_modified_label = nil,
         }
         header.setup(expected)
         assert.are.same(expected, header.config)


### PR DESCRIPTION
## feat: add custom label support via `*_label` config options

Closes #33

### What does this PR do?

Adds optional `*_label` config options that allow users to override the default label text for each header field.

### Changes

- `config.lua`: new `*_label` options added to defaults, new `get_label()` helper function
- `core.lua`: all header fields now use `get_label()` instead of `constants` directly
- `README.md`: new section documenting the `*_label` options, defaults table updated
- `tests/header/setup_spec.lua`: new label defaults added to expected config
- `tests/header/add_headers_spec.lua`: new test case for custom labels

### Usage

```lua
require("header").setup({
    file_name_label = "File:",
    author_label = "Author:",
    project_label = "Project:",
    date_created_label = "Created:",
    date_modified_label = "Modified:",
})
```

### Notes

- Default is `nil` for all `*_label` options → fully backwards compatible, no breaking change
- When `nil`, the built-in label from `constants` is used as before