### PR TITLE
refactor(licenses): align token names with config keys

### DIFF
--- a/lua/header/licenses/agpl3.lua
+++ b/lua/header/licenses/agpl3.lua
@@ -1,6 +1,6 @@
 local M = [[
 {{ project }}
-Copyright (C) {{ year }}  {{ organization }}
+Copyright (C) {{ year }}  {{ author }}
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by

--- a/lua/header/licenses/apache.lua
+++ b/lua/header/licenses/apache.lua
@@ -1,5 +1,5 @@
 local M = [[
-Copyright {{ year }} {{ organization }}
+Copyright {{ year }} {{ author }}
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lua/header/licenses/bsd2.lua
+++ b/lua/header/licenses/bsd2.lua
@@ -1,5 +1,5 @@
 local M = [[
-Copyright (c) {{ year }}, {{ organization }}
+Copyright (c) {{ year }}, {{ author }}
 
 All rights reserved.
 

--- a/lua/header/licenses/bsd3.lua
+++ b/lua/header/licenses/bsd3.lua
@@ -1,5 +1,5 @@
 local M = [[
-Copyright (c) {{ year }}, {{ organization }}
+Copyright (c) {{ year }}, {{ author }}
 
 All rights reserved.
 

--- a/lua/header/licenses/cc0.lua
+++ b/lua/header/licenses/cc0.lua
@@ -1,5 +1,5 @@
 local M = [[
-{{ project }} by {{ organization }}
+{{ project }} by {{ author }}
 
 To the extent possible under law, the person who associated CC0 with
 {{ project }} has waived all copyright and related or neighboring rights

--- a/lua/header/licenses/gpl3.lua
+++ b/lua/header/licenses/gpl3.lua
@@ -1,6 +1,6 @@
 local M = [[
 {{ project }}
-Copyright (C) {{ year }}  {{ organization }}
+Copyright (C) {{ year }}  {{ author }}
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/lua/header/licenses/isc.lua
+++ b/lua/header/licenses/isc.lua
@@ -1,5 +1,5 @@
 local M = [[
-Copyright (c) {{ year }}, {{ organization }}
+Copyright (c) {{ year }}, {{ author }}
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/lua/header/licenses/mit.lua
+++ b/lua/header/licenses/mit.lua
@@ -1,5 +1,5 @@
 local M = [[
-Copyright (c) {{ year }} {{ organization }}
+Copyright (c) {{ year }} {{ author }}
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/lua/header/licenses/wtfpl.lua
+++ b/lua/header/licenses/wtfpl.lua
@@ -1,5 +1,5 @@
 local M = [[
-Copyright © {{ year }} {{ organization }}
+Copyright © {{ year }} {{ author }}
 This work is free. You can redistribute it and/or modify it under the
 terms of the Do What The Fuck You Want To Public License, Version 2,
 as published by Sam Hocevar. See the COPYING file or http://www.wtfpl.net/

--- a/lua/header/licenses/x11.lua
+++ b/lua/header/licenses/x11.lua
@@ -1,5 +1,5 @@
 local M = [[
-Copyright (C) {{ year }} {{ organization }}
+Copyright (C) {{ year }} {{ author }}
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -15,17 +15,17 @@ included in all copies or substantial portions of the Software.
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL {{ organization }} BE LIABLE FOR ANY
+NONINFRINGEMENT. IN NO EVENT SHALL {{ author }} BE LIABLE FOR ANY
 CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-Except as contained in this notice, the name of {{ organization }} shall
+Except as contained in this notice, the name of {{ author }} shall
 not be used in advertising or otherwise to promote the sale, use or
 other dealings in this Software without prior written authorization
-from {{ organization }}.
+from {{ author }}.
 
-{{ project }} is a trademark of {{ organization }}.
+{{ project }} is a trademark of {{ author }}.
 ]]
 
 return M

--- a/lua/header/licenses/zlib.lua
+++ b/lua/header/licenses/zlib.lua
@@ -1,5 +1,5 @@
 local M = [[
-Copyright (c) {{ year }} {{ organization }}
+Copyright (c) {{ year }} {{ author }}
 
 This software is provided 'as-is', without any express or implied
 warranty. In no event will the authors be held liable for any damages

--- a/lua/header/util.lua
+++ b/lua/header/util.lua
@@ -16,7 +16,7 @@ end
 
 function M.replace_all_tokens(license_text, header)
     license_text = replace_token(license_text, "project", header.config.project)
-    license_text = replace_token(license_text, "organization", header.config.author)
+    license_text = replace_token(license_text, "author", header.config.author)
     license_text = replace_token(license_text, "year", os.date("%Y"))
     return license_text
 end


### PR DESCRIPTION
Rename `{{ organization }}` to `{{ author }}` in all license templates to match the actual config key used in `replace_all_tokens()`.